### PR TITLE
Fixed Reconciliation Client and added more generic error catching

### DIFF
--- a/lib/register_sources_oc/clients/reconciliation_client.rb
+++ b/lib/register_sources_oc/clients/reconciliation_client.rb
@@ -9,13 +9,15 @@ module RegisterSourcesOc
       class Error < StandardError
       end
 
-      def initialize(logger: Logger.new(nil))
+      def initialize(logger: Logger.new($stdout))
         @http = Net::HTTP::Persistent.new(name: self.class.name)
         @logger = logger
       end
 
       def reconcile(jurisdiction_code, search_query)
         uri = URI("https://opencorporates.com/reconcile/#{jurisdiction_code}?query=" + escape(search_query))
+
+        logger.info("Reconciling uri: #{uri}")
 
         response = @http.request(uri)
 
@@ -32,7 +34,10 @@ module RegisterSourcesOc
           jurisdiction_code:,
           company_number:,
         }
-      rescue Net::HTTP::Persistent::Error => e
+      # rescue Net::HTTP::Persistent::Error => e
+      #  logger.info("Received #{e.inspect} when reconciling \"#{search_query}\" (#{jurisdiction_code})")
+      #  nil
+      rescue StandardError => e
         logger.info("Received #{e.inspect} when reconciling \"#{search_query}\" (#{jurisdiction_code})")
         nil
       end

--- a/lib/register_sources_oc/services/resolver_service.rb
+++ b/lib/register_sources_oc/services/resolver_service.rb
@@ -37,7 +37,7 @@ module RegisterSourcesOc
 
         # Reconcile if necessary
         unless company_number
-          reconciliation_response = reconcile(request)
+          reconciliation_response = reconcile(request, jurisdiction_code)
 
           return ResolverResponse.new(resolved: false, jurisdiction_code:) unless reconciliation_response.reconciled
 
@@ -68,10 +68,10 @@ module RegisterSourcesOc
 
       attr_reader :company_service, :reconciliation_service, :jurisdiction_code_service
 
-      def reconcile(request)
+      def reconcile(request, jurisdiction_code)
         reconciliation_service.reconcile(
           ReconciliationRequest.new(
-            jurisdiction_code: request.jurisdiction_code,
+            jurisdiction_code:,
             name: request.name,
           ),
         )

--- a/spec/unit/clients/reconciliation_client_spec.rb
+++ b/spec/unit/clients/reconciliation_client_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe RegisterSourcesOc::Clients::ReconciliationClient do
       expect(response).to be_nil
     end
 
-    it 'raises an exception for response errors' do
+    it 'returns nil for response errors' do
       @stub.to_return(status: 500)
 
-      expect { subject.reconcile(@jurisdiction_code, @name) }.to raise_error(described_class::Error)
+      expect(subject.reconcile(@jurisdiction_code, @name)).to be_nil
     end
   end
 end


### PR DESCRIPTION
This fixes a typo which prevented the reconciliation client from being able to reconcile company numbers.

An additional issue is that OpenCorporates have protected the Reconciliation API, so only white-listed IPs can now access this.
Since in this scenario the records should still be processed but just without a company number having been resolved, it seems easiest to just catch all errors for now.