### PR TITLE
[#12] Services::ResolverService: extend resolve to merge add ids

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -95,7 +95,7 @@ RSpec/MultipleExpectations:
 # Offense count: 31
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:
-  Max: 11
+  Max: 13
 
 # Offense count: 72
 # Configuration parameters: EnforcedStyle, IgnoreSharedExamples.

--- a/lib/register_sources_oc/services/resolver_service.rb
+++ b/lib/register_sources_oc/services/resolver_service.rb
@@ -1,10 +1,10 @@
+require 'register_sources_oc/repositories/add_id_repository'
 require 'register_sources_oc/services/company_service'
-require 'register_sources_oc/services/reconciliation_service'
 require 'register_sources_oc/services/jurisdiction_code_service'
-
+require 'register_sources_oc/services/reconciliation_service'
+require 'register_sources_oc/structs/reconciliation_request'
 require 'register_sources_oc/structs/resolver_request'
 require 'register_sources_oc/structs/resolver_response'
-require 'register_sources_oc/structs/reconciliation_request'
 
 module RegisterSourcesOc
   module Services
@@ -12,11 +12,13 @@ module RegisterSourcesOc
       def initialize(
         company_service: CompanyService.new,
         reconciliation_service: ReconciliationService.new,
-        jurisdiction_code_service: JurisdictionCodeService.new
+        jurisdiction_code_service: JurisdictionCodeService.new,
+        add_id_repository: Repositories::AddIdRepository.new
       )
         @company_service = company_service
         @reconciliation_service = reconciliation_service
         @jurisdiction_code_service = jurisdiction_code_service
+        @add_id_repository = add_id_repository
       end
 
       def resolve(request)
@@ -55,12 +57,17 @@ module RegisterSourcesOc
           end
         end
 
+        add_ids = @add_id_repository.search_by_number(
+          jurisdiction_code:, company_number:,
+        ).map(&:record)
+
         ResolverResponse[{
           resolved: !company.nil?,
           jurisdiction_code:,
           company_number:,
           reconciliation_response:,
           company:,
+          add_ids:,
         }.compact]
       end
 

--- a/lib/register_sources_oc/structs/resolver_response.rb
+++ b/lib/register_sources_oc/structs/resolver_response.rb
@@ -1,8 +1,9 @@
 require 'dry-types'
 require 'dry-struct'
 
-require_relative 'reconciliation_response'
+require_relative 'add_id'
 require_relative 'company'
+require_relative 'reconciliation_response'
 
 module RegisterSourcesOc
   module Types
@@ -17,5 +18,6 @@ module RegisterSourcesOc
     attribute? :company_number, Types::String
     attribute? :reconciliation_response, ReconciliationResponse.optional
     attribute? :company, Company.optional
+    attribute? :add_ids, Types.Array(AddId)
   end
 end


### PR DESCRIPTION
Look up additional identifiers, such as LEIs, using the existing repository, and add them to the resolved response.

It was thought that LEIs could be added to register-sources-oc `Services::CompanyService` `get_company`, with the actual functionality implemented by `BulkDataCompanyService` and `OcApiCompanyService` `get_company`. Although this would work fine for `BulkDataCompanyService`, it turns out that OpenCorporates API does not return LEIs if the `sparse: true` parameter is used. Sparse is the current default, and although overridden in register-v2 (and register), register-transformer-* uses the default sparse. Changing this would be problematic, because non-sparse API calls return far more data: for 1 company examined, 17x more data!

After a discussion with @spacesnottabs, this alternative approach was selected. This will avoid the sparse API calls issue, and will have the result that regardless of whether `BulkDataCompanyService` or `OcApiCompanyService` is used to service the request, bulk data will be used to supply LEIs, and the OC API will never supply this information. This would appear to satisfy the current objectives.