### PR TITLE
[#188] refactor lib/

### DIFF
--- a/lib/register_sources_oc.rb
+++ b/lib/register_sources_oc.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'register_sources_oc/types'
 require_relative 'register_sources_oc/version'
 
 module RegisterSourcesOc

--- a/lib/register_sources_oc/clients/google_geocoder_client.rb
+++ b/lib/register_sources_oc/clients/google_geocoder_client.rb
@@ -2,7 +2,7 @@
 
 require 'geokit'
 
-require 'register_sources_oc/structs/geocoder_response'
+require_relative '../structs/geocoder_response'
 
 module RegisterSourcesOc
   module Clients

--- a/lib/register_sources_oc/clients/open_corporate_client.rb
+++ b/lib/register_sources_oc/clients/open_corporate_client.rb
@@ -1,21 +1,19 @@
 # frozen_string_literal: true
 
-require 'net/http/persistent'
-require 'logger'
-require 'json'
+require 'active_support'
 require 'addressable'
 require 'faraday'
 require 'faraday_middleware'
-require 'active_support'
+require 'json'
+require 'logger'
+require 'net/http/persistent'
 
 module RegisterSourcesOc
   module Clients
     class OpenCorporateClient
-      API_VERSION = 'v0.4.6'
-      CACHE_EXPIRY_SECS = 60 * 60 * 24 * 31 # 31.days.to_i
+      TimeoutError = Class.new(StandardError)
 
-      class TimeoutError < StandardError
-      end
+      API_VERSION = 'v0.4.6'
 
       def self.new_for_imports
         new(

--- a/lib/register_sources_oc/clients/reconciliation_client.rb
+++ b/lib/register_sources_oc/clients/reconciliation_client.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
-require 'net/http/persistent'
 require 'cgi'
 require 'json'
 require 'logger'
+require 'net/http/persistent'
 
 module RegisterSourcesOc
   module Clients
     class ReconciliationClient
-      class Error < StandardError
-      end
+      Error = Class.new(StandardError)
 
       def initialize(logger: Logger.new($stdout))
         @http = Net::HTTP::Persistent.new(name: self.class.name)
@@ -36,9 +35,6 @@ module RegisterSourcesOc
           jurisdiction_code:,
           company_number:
         }
-      # rescue Net::HTTP::Persistent::Error => e
-      #  logger.info("Received #{e.inspect} when reconciling \"#{search_query}\" (#{jurisdiction_code})")
-      #  nil
       rescue StandardError => e
         logger.info("Received #{e.inspect} when reconciling \"#{search_query}\" (#{jurisdiction_code})")
         nil

--- a/lib/register_sources_oc/config/elasticsearch.rb
+++ b/lib/register_sources_oc/config/elasticsearch.rb
@@ -4,10 +4,9 @@ require 'elasticsearch'
 
 module RegisterSourcesOc
   module Config
-    ELASTICSEARCH_CLIENT = Elasticsearch::Client.new
-
-    ES_ADD_IDS_INDEX   = 'add_ids'
-    ES_ALT_NAMES_INDEX = 'alt_names'
-    ES_COMPANIES_INDEX = 'companies'
+    ELASTICSEARCH_CLIENT          = Elasticsearch::Client.new
+    ELASTICSEARCH_INDEX_ADD_IDS   = 'add_ids'
+    ELASTICSEARCH_INDEX_ALT_NAMES = 'alt_names'
+    ELASTICSEARCH_INDEX_COMPANIES = 'companies'
   end
 end

--- a/lib/register_sources_oc/repositories/add_id_repository.rb
+++ b/lib/register_sources_oc/repositories/add_id_repository.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/indifferent_access'
 require 'digest'
 require 'json'
-require 'register_sources_oc/config/elasticsearch'
-require 'register_sources_oc/structs/add_id'
-require 'active_support/core_ext/hash/indifferent_access'
+
+require_relative '../config/elasticsearch'
+require_relative '../structs/add_id'
 
 module RegisterSourcesOc
   module Repositories
@@ -13,7 +14,7 @@ module RegisterSourcesOc
 
       SearchResult = Struct.new(:record, :score)
 
-      def initialize(client: Config::ELASTICSEARCH_CLIENT, index: Config::ES_ADD_IDS_INDEX)
+      def initialize(client: Config::ELASTICSEARCH_CLIENT, index: Config::ELASTICSEARCH_INDEX_ADD_IDS)
         @client = client
         @index = index
       end

--- a/lib/register_sources_oc/repositories/alt_name_repository.rb
+++ b/lib/register_sources_oc/repositories/alt_name_repository.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/indifferent_access'
 require 'digest'
 require 'json'
-require 'register_sources_oc/config/elasticsearch'
-require 'register_sources_oc/structs/alt_name'
-require 'active_support/core_ext/hash/indifferent_access'
+
+require_relative '../config/elasticsearch'
+require_relative '../structs/alt_name'
 
 module RegisterSourcesOc
   module Repositories
     class AltNameRepository
       SearchResult = Struct.new(:record, :score)
 
-      def initialize(client: Config::ELASTICSEARCH_CLIENT, index: Config::ES_ALT_NAMES_INDEX)
+      def initialize(client: Config::ELASTICSEARCH_CLIENT, index: Config::ELASTICSEARCH_INDEX_ALT_NAMES)
         @client = client
         @index = index
       end

--- a/lib/register_sources_oc/repositories/company_repository.rb
+++ b/lib/register_sources_oc/repositories/company_repository.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/indifferent_access'
 require 'digest'
 require 'json'
-require 'register_sources_oc/config/elasticsearch'
-require 'register_sources_oc/structs/company'
-require 'active_support/core_ext/hash/indifferent_access'
+
+require_relative '../config/elasticsearch'
+require_relative '../structs/company'
 
 module RegisterSourcesOc
   module Repositories
     class CompanyRepository
       SearchResult = Struct.new(:record, :score)
 
-      def initialize(client: Config::ELASTICSEARCH_CLIENT, index: Config::ES_COMPANIES_INDEX)
+      def initialize(client: Config::ELASTICSEARCH_CLIENT, index: Config::ELASTICSEARCH_INDEX_COMPANIES)
         @client = client
         @index = index
       end

--- a/lib/register_sources_oc/services/bulk_data_company_service.rb
+++ b/lib/register_sources_oc/services/bulk_data_company_service.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require 'elasticsearch'
-require 'register_sources_oc/repositories/company_repository'
+
+require_relative '../repositories/company_repository'
 
 module RegisterSourcesOc
   module Services

--- a/lib/register_sources_oc/services/company_service.rb
+++ b/lib/register_sources_oc/services/company_service.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-require 'register_sources_oc/utils/result_comparer'
-
+require_relative '../utils/result_comparer'
 require_relative 'bulk_data_company_service'
 require_relative 'oc_api_company_service'
 
 module RegisterSourcesOc
   module Services
     class CompanyService
-      InconsistentResponseError = Class.new(StandardError)
-
-      # services: [ { name: 'bulk', service: bulk_service }, { name: 'oc_api', service: oc_api_service }]
       def initialize(services: nil, verbose: false, comparison_mode: false, comparer: nil)
         @services = services || [
           { name: 'bulk', service: BulkDataCompanyService.new },

--- a/lib/register_sources_oc/services/es_index_creator.rb
+++ b/lib/register_sources_oc/services/es_index_creator.rb
@@ -1,124 +1,43 @@
 # frozen_string_literal: true
 
-require 'register_sources_oc/config/elasticsearch'
+require 'json'
+
+require_relative '../config/elasticsearch'
 
 module RegisterSourcesOc
   module Services
     class EsIndexCreator
+      MAPPINGS_ADD_IDS   = JSON.parse(File.read(File.expand_path('mappings/add_ids.json', __dir__)))
+      MAPPINGS_ALT_NAMES = JSON.parse(File.read(File.expand_path('mappings/alt_names.json', __dir__)))
+      MAPPINGS_COMPANIES = JSON.parse(File.read(File.expand_path('mappings/companies.json', __dir__)))
+
       def initialize(
         client: Config::ELASTICSEARCH_CLIENT,
-        companies_index: Config::ES_COMPANIES_INDEX,
-        alt_names_index: Config::ES_ALT_NAMES_INDEX,
-        add_ids_index: Config::ES_ADD_IDS_INDEX
+        companies_index: Config::ELASTICSEARCH_INDEX_COMPANIES,
+        alt_names_index: Config::ELASTICSEARCH_INDEX_ALT_NAMES,
+        add_ids_index: Config::ELASTICSEARCH_INDEX_ADD_IDS
       )
         @client = client
-        @companies_index = companies_index
-        @alt_names_index = alt_names_index
         @add_ids_index = add_ids_index
-      end
-
-      def create_companies_index
-        client.indices.create index: companies_index, body: {
-          mappings: {
-            properties: {
-              company_number: {
-                type: 'keyword'
-              },
-              jurisdiction_code: {
-                type: 'keyword'
-              },
-              name: {
-                type: 'text',
-                fields: {
-                  raw: {
-                    type: 'keyword'
-                  }
-                }
-              },
-              company_type: {
-                type: 'keyword'
-              },
-              incorporation_date: {
-                type: 'keyword'
-              },
-              dissolution_date: {
-                type: 'keyword'
-              },
-              restricted_for_marketing: {
-                type: 'boolean'
-              },
-              registered_address_in_full: {
-                type: 'text',
-                fields: {
-                  raw: {
-                    type: 'keyword'
-                  }
-                }
-              },
-              registered_address_country: {
-                type: 'keyword'
-              }
-            }
-          }
-        }
+        @alt_names_index = alt_names_index
+        @companies_index = companies_index
       end
 
       def create_add_ids_index
-        client.indices.create index: add_ids_index, body: {
-          mappings: {
-            properties: {
-              company_number: {
-                type: 'keyword'
-              },
-              jurisdiction_code: {
-                type: 'keyword'
-              },
-              uid: {
-                type: 'keyword'
-              },
-              identifier_system_code: {
-                type: 'keyword'
-              }
-            }
-          }
-        }
+        client.indices.create index: add_ids_index, body: { mappings: MAPPINGS_ADD_IDS }
       end
 
       def create_alt_names_index
-        client.indices.create index: alt_names_index, body: {
-          mappings: {
-            properties: {
-              company_number: {
-                type: 'keyword'
-              },
-              jurisdiction_code: {
-                type: 'keyword'
-              },
-              name: {
-                type: 'text',
-                fields: {
-                  raw: {
-                    type: 'keyword'
-                  }
-                }
-              },
-              type: {
-                type: 'keyword'
-              },
-              start_date: {
-                type: 'keyword'
-              },
-              end_date: {
-                type: 'keyword'
-              }
-            }
-          }
-        }
+        client.indices.create index: alt_names_index, body: { mappings: MAPPINGS_ALT_NAMES }
+      end
+
+      def create_companies_index
+        client.indices.create index: companies_index, body: { mappings: MAPPINGS_COMPANIES }
       end
 
       private
 
-      attr_reader :client, :companies_index, :alt_names_index, :add_ids_index
+      attr_reader :client, :add_ids_index, :alt_names_index, :companies_index
     end
   end
 end

--- a/lib/register_sources_oc/services/jurisdiction_code_service.rb
+++ b/lib/register_sources_oc/services/jurisdiction_code_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'register_sources_oc/clients/open_corporate_client'
-require 'register_sources_oc/clients/google_geocoder_client'
+require_relative '../clients/google_geocoder_client'
+require_relative '../clients/open_corporate_client'
 
 module RegisterSourcesOc
   module Services

--- a/lib/register_sources_oc/services/mappings/add_ids.json
+++ b/lib/register_sources_oc/services/mappings/add_ids.json
@@ -1,0 +1,16 @@
+{
+  "properties": {
+    "company_number": {
+      "type": "keyword"
+    },
+    "jurisdiction_code": {
+      "type": "keyword"
+    },
+    "uid": {
+      "type": "keyword"
+    },
+    "identifier_system_code": {
+      "type": "keyword"
+    }
+  }
+}

--- a/lib/register_sources_oc/services/mappings/alt_names.json
+++ b/lib/register_sources_oc/services/mappings/alt_names.json
@@ -1,0 +1,27 @@
+{
+  "properties": {
+    "company_number": {
+      "type": "keyword"
+    },
+    "jurisdiction_code": {
+      "type": "keyword"
+    },
+    "name": {
+      "type": "text",
+      "fields": {
+        "raw": {
+          "type": "keyword"
+        }
+      }
+    },
+    "type": {
+      "type": "keyword"
+    },
+    "start_date": {
+      "type": "keyword"
+    },
+    "end_date": {
+      "type": "keyword"
+    }
+  }
+}

--- a/lib/register_sources_oc/services/mappings/companies.json
+++ b/lib/register_sources_oc/services/mappings/companies.json
@@ -1,0 +1,41 @@
+{
+  "properties": {
+    "company_number": {
+      "type": "keyword"
+    },
+    "jurisdiction_code": {
+      "type": "keyword"
+    },
+    "name": {
+      "type": "text",
+      "fields": {
+        "raw": {
+          "type": "keyword"
+        }
+      }
+    },
+    "company_type": {
+      "type": "keyword"
+    },
+    "incorporation_date": {
+      "type": "keyword"
+    },
+    "dissolution_date": {
+      "type": "keyword"
+    },
+    "restricted_for_marketing": {
+      "type": "boolean"
+    },
+    "registered_address_in_full": {
+      "type": "text",
+      "fields": {
+        "raw": {
+          "type": "keyword"
+        }
+      }
+    },
+    "registered_address_country": {
+      "type": "keyword"
+    }
+  }
+}

--- a/lib/register_sources_oc/services/oc_api_company_service.rb
+++ b/lib/register_sources_oc/services/oc_api_company_service.rb
@@ -2,15 +2,16 @@
 
 require 'forwardable'
 
-require 'register_sources_oc/clients/open_corporate_client'
+require_relative '../clients/open_corporate_client'
 
 module RegisterSourcesOc
   module Services
     class OcApiCompanyService
-      FIELDS = %i[company_number jurisdiction_code name company_type incorporation_date dissolution_date
-                  restricted_for_marketing registered_address_in_full registered_address_country].freeze
-
       extend Forwardable
+
+      FIELDS = %i[company_number jurisdiction_code name company_type
+                  incorporation_date dissolution_date restricted_for_marketing
+                  registered_address_in_full registered_address_country].freeze
 
       def_delegators :@open_corporate_client, :get_jurisdiction_code
 

--- a/lib/register_sources_oc/services/reconciliation_service.rb
+++ b/lib/register_sources_oc/services/reconciliation_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'register_sources_oc/clients/reconciliation_client'
-require 'register_sources_oc/structs/reconciliation_response'
+require_relative '../clients/reconciliation_client'
+require_relative '../structs/reconciliation_response'
 
 module RegisterSourcesOc
   module Services

--- a/lib/register_sources_oc/services/resolver_service.rb
+++ b/lib/register_sources_oc/services/resolver_service.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'register_sources_oc/repositories/add_id_repository'
-require 'register_sources_oc/services/company_service'
-require 'register_sources_oc/services/jurisdiction_code_service'
-require 'register_sources_oc/services/reconciliation_service'
-require 'register_sources_oc/structs/reconciliation_request'
-require 'register_sources_oc/structs/resolver_request'
-require 'register_sources_oc/structs/resolver_response'
+require_relative '../repositories/add_id_repository'
+require_relative '../structs/reconciliation_request'
+require_relative '../structs/resolver_request'
+require_relative '../structs/resolver_response'
+require_relative 'company_service'
+require_relative 'jurisdiction_code_service'
+require_relative 'reconciliation_service'
 
 module RegisterSourcesOc
   module Services

--- a/lib/register_sources_oc/structs/add_id.rb
+++ b/lib/register_sources_oc/structs/add_id.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
-require 'dry-types'
-require 'dry-struct'
+require_relative '../types'
 
 module RegisterSourcesOc
-  module Types
-    include Dry.Types()
-  end
-
   class AddId < Dry::Struct
     transform_keys(&:to_sym)
 
-    attribute :company_number, Types::String.optional
-    attribute :jurisdiction_code, Types::String.optional
-    attribute :uid, Types::String.optional
+    attribute :company_number,         Types::String.optional
+    attribute :jurisdiction_code,      Types::String.optional
+    attribute :uid,                    Types::String.optional
     attribute :identifier_system_code, Types::String.optional
   end
 end

--- a/lib/register_sources_oc/structs/alt_name.rb
+++ b/lib/register_sources_oc/structs/alt_name.rb
@@ -1,21 +1,16 @@
 # frozen_string_literal: true
 
-require 'dry-types'
-require 'dry-struct'
+require_relative '../types'
 
 module RegisterSourcesOc
-  module Types
-    include Dry.Types()
-  end
-
   class AltName < Dry::Struct
     transform_keys(&:to_sym)
 
-    attribute :company_number, Types::String.optional
+    attribute :company_number,    Types::String.optional
     attribute :jurisdiction_code, Types::String.optional
-    attribute :name, Types::String.optional
-    attribute :type, Types::String.optional
-    attribute :start_date, Types::String.optional
-    attribute :end_date, Types::String.optional
+    attribute :name,              Types::String.optional
+    attribute :type,              Types::String.optional
+    attribute :start_date,        Types::String.optional
+    attribute :end_date,          Types::String.optional
   end
 end

--- a/lib/register_sources_oc/structs/company.rb
+++ b/lib/register_sources_oc/structs/company.rb
@@ -1,23 +1,18 @@
 # frozen_string_literal: true
 
-require 'dry-types'
-require 'dry-struct'
+require_relative '../types'
 
 module RegisterSourcesOc
-  module Types
-    include Dry.Types()
-  end
-
   class Company < Dry::Struct
     transform_keys(&:to_sym)
 
-    attribute :company_number, Types::String.optional
-    attribute :jurisdiction_code, Types::String.optional
-    attribute :name, Types::String.optional
-    attribute :company_type, Types::String.optional
-    attribute :incorporation_date, Types::String.optional
-    attribute :dissolution_date, Types::String.optional
-    attribute :restricted_for_marketing, Types::Strict::Bool.optional
+    attribute :company_number,             Types::String.optional
+    attribute :jurisdiction_code,          Types::String.optional
+    attribute :name,                       Types::String.optional
+    attribute :company_type,               Types::String.optional
+    attribute :incorporation_date,         Types::String.optional
+    attribute :dissolution_date,           Types::String.optional
+    attribute :restricted_for_marketing,   Types::Strict::Bool.optional
     attribute :registered_address_in_full, Types::String.optional
     attribute :registered_address_country, Types::String.optional
   end

--- a/lib/register_sources_oc/structs/geocoder_response.rb
+++ b/lib/register_sources_oc/structs/geocoder_response.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
-require 'dry-types'
-require 'dry-struct'
+require_relative '../types'
 
 module RegisterSourcesOc
-  module Types
-    include Dry.Types()
-  end
-
   class GeocoderResponse < Dry::Struct
     transform_keys(&:to_sym)
 
-    attribute? :country, Types::String
+    attribute? :country,      Types::String
     attribute? :country_code, Types::String
-    attribute? :state, Types::String.optional
-    attribute? :state_code, Types::String.optional
+    attribute? :state,        Types::String.optional
+    attribute? :state_code,   Types::String.optional
   end
 end

--- a/lib/register_sources_oc/structs/reconciliation_request.rb
+++ b/lib/register_sources_oc/structs/reconciliation_request.rb
@@ -1,17 +1,12 @@
 # frozen_string_literal: true
 
-require 'dry-types'
-require 'dry-struct'
+require_relative '../types'
 
 module RegisterSourcesOc
-  module Types
-    include Dry.Types()
-  end
-
   class ReconciliationRequest < Dry::Struct
     transform_keys(&:to_sym)
 
     attribute :jurisdiction_code, Types::String
-    attribute :name, Types::String
+    attribute :name,              Types::String
   end
 end

--- a/lib/register_sources_oc/structs/reconciliation_response.rb
+++ b/lib/register_sources_oc/structs/reconciliation_response.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
-require 'dry-types'
-require 'dry-struct'
+require_relative '../types'
 
 module RegisterSourcesOc
-  module Types
-    include Dry.Types()
-  end
-
   class ReconciliationResponse < Dry::Struct
     transform_keys(&:to_sym)
 
-    attribute :reconciled, Types::Nominal::Bool.optional
+    attribute :reconciled,        Types::Nominal::Bool.optional
     attribute :jurisdiction_code, Types::String
-    attribute :name, Types::String
-    attribute :company_number, Types::String.optional
+    attribute :name,              Types::String
+    attribute :company_number,    Types::String.optional
   end
 end

--- a/lib/register_sources_oc/structs/resolver_request.rb
+++ b/lib/register_sources_oc/structs/resolver_request.rb
@@ -1,20 +1,15 @@
 # frozen_string_literal: true
 
-require 'dry-types'
-require 'dry-struct'
+require_relative '../types'
 
 module RegisterSourcesOc
-  module Types
-    include Dry.Types()
-  end
-
   class ResolverRequest < Dry::Struct
     transform_keys(&:to_sym)
 
     attribute? :jurisdiction_code, Types::String
-    attribute? :company_number, Types::String
-    attribute? :country, Types::String
-    attribute? :region, Types::String.optional
-    attribute? :name, Types::String
+    attribute? :company_number,    Types::String
+    attribute? :country,           Types::String
+    attribute? :region,            Types::String.optional
+    attribute? :name,              Types::String
   end
 end

--- a/lib/register_sources_oc/structs/resolver_response.rb
+++ b/lib/register_sources_oc/structs/resolver_response.rb
@@ -1,25 +1,19 @@
 # frozen_string_literal: true
 
-require 'dry-types'
-require 'dry-struct'
-
+require_relative '../types'
 require_relative 'add_id'
 require_relative 'company'
 require_relative 'reconciliation_response'
 
 module RegisterSourcesOc
-  module Types
-    include Dry.Types()
-  end
-
   class ResolverResponse < Dry::Struct
     transform_keys(&:to_sym)
 
-    attribute :resolved, Types::Nominal::Bool.default(false)
-    attribute? :jurisdiction_code, Types::String
-    attribute? :company_number, Types::String
+    attribute  :resolved,                Types::Nominal::Bool.default(false)
+    attribute? :jurisdiction_code,       Types::String
+    attribute? :company_number,          Types::String
     attribute? :reconciliation_response, ReconciliationResponse.optional
-    attribute? :company, Company.optional
-    attribute? :add_ids, Types.Array(AddId)
+    attribute? :company,                 Company.optional
+    attribute? :add_ids,                 Types.Array(AddId)
   end
 end

--- a/lib/register_sources_oc/types.rb
+++ b/lib/register_sources_oc/types.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'dry-struct'
+require 'dry-types'
+
+module RegisterSourcesOc
+  module Types
+    include Dry.Types()
+  end
+end


### PR DESCRIPTION
Note that `Repositories::AddIdRepository`,
`Repositories::AltNamesRepository`, `Repositories::CompanyRepository` are in particular need of refactoring, given the cross-repo duplication. Only minimal changes are made in this pass, however.

---

References https://github.com/openownership/register/issues/188 .